### PR TITLE
Add analytics with new google tag manager tracking id

### DIFF
--- a/js/custom-google-analytics.js
+++ b/js/custom-google-analytics.js
@@ -1,0 +1,46 @@
+(function () {
+    // Add external script tags
+    function addExternalScript(externalCode, scriptType='script', target='head'){
+        const externalScriptTag = document.createElement(scriptType);
+        externalScriptTag.async = true;
+        externalScriptTag.src = externalCode;
+        document.querySelector(target).appendChild(externalScriptTag);
+    }
+    
+    // Add inline script tags
+    function addInlineScript(inlineCode, scriptType='script', target='head'){
+        const inlineScriptTag = document.createElement(scriptType);
+        inlineScriptTag.type = 'text/javascript';
+
+        // Methods of adding inner text sometimes don't work across browsers.
+        try {
+            inlineScriptTag.appendChild(document.createTextNode(inlineCode));
+        } catch (e) {
+            inlineScriptTag.text = inlineCode;
+        }
+
+        document.querySelector(target).appendChild(inlineScriptTag);
+    }
+
+
+    // Google Analytics 4
+    // Added as variable/constant in GTM
+    // const trackingId_GA4 = 'G-3CXC97RWEK';
+ 
+
+    // Google Tag Manager
+    const trackingId_GTM = 'GTM-WSHSDQ5';
+
+    const gtmHeadCode =
+        `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','${trackingId_GTM}');`;
+
+    const gtmBodyCode = `<iframe src="https://www.googletagmanager.com/ns.html?id=${trackingId_GTM}"
+        height="0" width="0" style="display:none;visibility:hidden"></iframe>`;
+
+    addInlineScript(gtmHeadCode);
+    addInlineScript(gtmBodyCode, 'noscript', 'body');
+})();


### PR DESCRIPTION
**Add analytics with new google tag manager tracking id**
* * *

# What does this Pull Request do?
Adds the analytics we are using to reference the new tracking id that is being applied across library systems.

# How should this be tested?
* Spin up local version of Hollis Images
* Inspect code to see that the new id (GTM-WSHSDQ5) and code are in the correct places (refer to [GTM installation instructions](https://tagmanager.google.com/#/admin/accounts/6006463004/containers/62544873/install?containerDraftId=21), this is the code that should be in the `<head>` and `<body>` parts of the page)
* Test in preview mode using tagmanager.google.com ([video ](https://drive.google.com/file/d/1wB3iJphfdrj28KLRgw456cnKeMNcqKb2/view?usp=sharing)for how you can check this locally *works best to test in Chrome)
* Once in production, we can test again to confirm that it's firing correctly on both the Google Tag Manager and Google Analytics side of things

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? NA
- integration tests? NA

# Interested parties
@cbaksik 