### PR TITLE
Bring back the alert message and remove extra whitespace.

### DIFF
--- a/html/alert-jsondata.html
+++ b/html/alert-jsondata.html
@@ -4,5 +4,5 @@
 "description":"Due to weather conditions there will be no library deliveries Thursday or Friday. Normal activites will resume Monday.",
 "link":"http://nrs.harvard.edu/urn-3:hul.ois:dsref",
 "linkText":"More information on the delivery schedule.",
-"status":"on"
+"status":"off"
 }

--- a/js/prm-topbar-after.js
+++ b/js/prm-topbar-after.js
@@ -2,7 +2,6 @@
  * Created by samsan on 6/29/17.
  */
 
-/*
 (function () {
 
     angular.module('viewCustom')
@@ -56,4 +55,3 @@
     });
 
 })();
-*/


### PR DESCRIPTION
This restores the ability to display alert messages. I also turned the (old?) alert message off, so that it doesn’t get deployed to the live site inadvertently.

This commit also removes the weird gap on the landing page as well.

I tested search results with this enabled and disabled and saw no difference in the load times, so this should be safe to put back on the live site.

cc: @ktamaral