### PR TITLE
LTSDISC-7 Remove custom alert url from topbar, and remove topbar

### DIFF
--- a/html/alert-jsondata.html
+++ b/html/alert-jsondata.html
@@ -4,5 +4,5 @@
 "description":"Due to weather conditions there will be no library deliveries Thursday or Friday. Normal activites will resume Monday.",
 "link":"http://nrs.harvard.edu/urn-3:hul.ois:dsref",
 "linkText":"More information on the delivery schedule.",
-"status":"off"
+"status":"on"
 }

--- a/js/custom-alert.js
+++ b/js/custom-alert.js
@@ -4,34 +4,60 @@
  * If you need to turn off or on, just set status in json file to on or off
  */
 
+/*
+  Updated on February 13, 2024
+  Removed alert url vm.getUrl() from prm-topbar-after and moved it into the custom-alert.js component 
+  That way we can disable prm-topbar-after.js without affecting the alert message
+*/
+
 (function () {
     angular.module('viewCustom')
         .controller('customAlertCtrl',['prmSearchService','$scope',function (prmSearchService, $scope) {
-            let vm=this;
-            let cs=prmSearchService;
-            vm.apiUrl={};
-            vm.alertMsg={};
+            let vm = this;
+            let cs = prmSearchService;
+            vm.apiUrl = {};
+            vm.alertMsg = {};
+
+            // get rest endpoint Url
+            vm.getUrl=function () {
+                var configFile = cs.getEnv();
+                var url = '/primo-explore/custom/HVD_IMAGES/html/'+configFile;
+                cs.getAjax(url,'','get')
+                    .then(function (res) {
+                        vm.api=res.data;
+                        // Set alert url
+                        vm.alertUrl = vm.api.alertUrl;
+                        // Set api url
+                        cs.setApi(vm.api);
+                        },
+                        function (error) {
+                            console.error(error);
+                        }
+                    )
+            };
 
             vm.$onInit=()=> {
                 vm.apiUrl=cs.getApi();
-                $scope.$watch('vm.apiUrl.alertUrl',()=>{
-                   if(vm.apiUrl.alertUrl) {
-                       cs.getAjax(vm.apiUrl.alertUrl,'','get')
-                           .then((res)=>{
-                                vm.alertMsg = res.data;
-                           },
-                               (err)=>{
-                                    console.log(err);
-                               }
-                           )
-                   }
+                // Get alert url
+                vm.getUrl();
+                // Watch alert url
+                $scope.$watch('vm.alertUrl',() => {
+                    if(vm.alertUrl) {
+                        cs.getAjax(vm.alertUrl,'','get')
+                        .then((res)=>{
+                            vm.alertMsg = res.data;
+                        },
+                        (err) => {
+                            console.log(err);
+                        })
+                    }
                 });
             };
             
         }]);
 
     angular.module('viewCustom')
-        .component('customAlert',{
+        .component('customAlert', {
             bindings:{parentCtrl:'<'},
             controller: 'customAlertCtrl',
             controllerAs:'vm',

--- a/js/prm-logo-after.js
+++ b/js/prm-logo-after.js
@@ -3,18 +3,13 @@
  * This component add customize logo and Hollis Images text
  */
 
-
 (function () {
     angular.module('viewCustom')
     .controller('prmLogoAfterController', [ '$element', function ($element) {
-
+        var vm = this;
         vm.$onInit=function() {
         };
-
-
-
     }]);
-
 
     angular.module('viewCustom')
     .component('prmLogoAfter', {
@@ -24,5 +19,3 @@
     });
 
 })();
-
-

--- a/js/prm-topbar-after.js
+++ b/js/prm-topbar-after.js
@@ -2,6 +2,7 @@
  * Created by samsan on 6/29/17.
  */
 
+/*
 (function () {
 
     angular.module('viewCustom')
@@ -19,7 +20,7 @@
                         cs.setApi(vm.api);
                     },
                     function (error) {
-                        console.log(error);
+                        console.error(error);
                     }
                 )
         };
@@ -55,3 +56,4 @@
     });
 
 })();
+*/


### PR DESCRIPTION
Remove custom alert url from topbar, and remove topbar

The top bar had some code in it that the custom alert was relying on and that had to be moved into the alert component.

That way the custom top bar could be removed without affecting the alert message display.
