### PR TITLE
Truncating titles on search results to 5 lines.

### DIFF
--- a/css/thumbnail.css
+++ b/css/thumbnail.css
@@ -229,6 +229,12 @@ prm-view-online-after md-grid-list > md-grid-tile {
     background-color: inherit;
 }
 
+prm-brief-result .item-title span {
+  -webkit-box-orient: vertical;
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  overflow: hidden;
+}
 
 @media only screen and (max-width: 800px) {
     .hvPanel {


### PR DESCRIPTION
This truncates the title text on search results pages to be 5 lines followed by an ellipsis. 

If the title is shorter than 5 lines it is not truncated.

I have tested this in Firefox, Chrome and Safari. 

Example:
![baseball-truncate](https://github.com/cbaksik/HVD_IMAGES/assets/40801910/686ef8da-7fd2-47e1-919d-2d66c873bda2)
