### PR TITLE
Setting minimum height of search result cells to 100px.

### DIFF
--- a/css/thumbnail.css
+++ b/css/thumbnail.css
@@ -229,6 +229,9 @@ prm-view-online-after md-grid-list > md-grid-tile {
     background-color: inherit;
 }
 
+prm-brief-result-container {
+    min-height: 100px;
+}
 
 @media only screen and (max-width: 800px) {
     .hvPanel {


### PR DESCRIPTION
To create a less jarring visual experience, the grid view has a minimum height of 100px to the cells' styling so that they fill out the approximate space on the page the results will occupy once they fully load.
