### PR TITLE
Fix detail page

### DIFF
--- a/css/thumbnail.css
+++ b/css/thumbnail.css
@@ -236,13 +236,14 @@ prm-brief-result .item-title span {
   overflow: hidden;
 }
 
-prm-search-result-thumbnail-container img {
+prm-search prm-search-result-thumbnail-container img {
     width: auto;
 }
 
 prm-brief-result-container {
     min-height: 100px;
 }
+
 
 @media only screen and (max-width: 800px) {
     .hvPanel {

--- a/css/thumbnail.css
+++ b/css/thumbnail.css
@@ -244,7 +244,6 @@ prm-brief-result-container {
     min-height: 100px;
 }
 
-
 @media only screen and (max-width: 800px) {
     .hvPanel {
         padding-bottom:70px;


### PR DESCRIPTION
This fixes the issue where the thumbnail on the detail page was overlapping with the title.

![Screenshot 2024-02-21 at 10 58 44](https://github.com/cbaksik/HVD_IMAGES/assets/40801910/d31a6aba-34ff-466c-8dc2-381176e56d1a)
