### PR TITLE
Restoring image dimensions in item detail view.

### DIFF
--- a/css/singleImage.css
+++ b/css/singleImage.css
@@ -1,11 +1,7 @@
 
 single-image #iframe {
-    width:700px;
-    height:650px;
-    /*
     width:100%;
     height:90vh;
-    */
     border: 1px solid lightgrey;
     margin:0;
     padding:0;


### PR DESCRIPTION
When browsing the item detail view of a search result for a single image or a single image view of a record with components, a user will observe that:

- the image viewer is presenting the image at the same set of dimensions as before the code changes were applied