### PR TITLE
adjusting padding and breakpoints to make truncation more readable

### DIFF
--- a/css/prm-search-results.css
+++ b/css/prm-search-results.css
@@ -9,17 +9,17 @@
   flex: 0 0 33.33% !important;
   max-width: 33.33% !important;
   box-sizing: border-box !important;
-  padding-right: 10px !important;
+  /* padding-right: 10px !important; */
 }
-  
-@media (max-width: 1200px) {
+
+@media (max-width: 1450px) {
   .list-item-wrapper {
     flex: 0 0 50% !important;
     max-width: 50% !important;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 700px) {
   .list-item-wrapper {
     flex: 0 0 100% !important;
     max-width: 100% !important;
@@ -34,6 +34,13 @@ prm-brief-result-container .result-item-image {
   /*width: 100% !important;
   height: auto !important;*/
   flex: 0 0 auto !important;
+}
+
+prm-brief-result-container .result-item-text {
+  padding-right:0;
+}
+.__xs prm-brief-result-container .result-item-text {
+  padding-left: .35em;
 }
 
 /* hide medtia type label 'image' */

--- a/css/thumbnail.css
+++ b/css/thumbnail.css
@@ -229,6 +229,10 @@ prm-view-online-after md-grid-list > md-grid-tile {
     background-color: inherit;
 }
 
+prm-brief-result .item-title {
+    max-width: 100%;
+}
+
 prm-brief-result .item-title span {
   -webkit-box-orient: vertical;
   display: -webkit-box;


### PR DESCRIPTION
Adjusting padding and breakpoints to make truncation more readable.

Old way:
![WeirdTruncation](https://github.com/cbaksik/HVD_IMAGES/assets/40801910/8e523f2b-e248-4cda-9524-d9323f006587)

New way:
![NewTruncation](https://github.com/cbaksik/HVD_IMAGES/assets/40801910/fb8bfaa0-fb41-469a-a41b-d79d12efc911)
