### PR TITLE
LTSDISC-S03 front-end changes 

### DIFF
--- a/css/hvd_images.css
+++ b/css/hvd_images.css
@@ -285,3 +285,7 @@ prm-search-result-availability-line {
     display: none;
 }
 
+/* account dropdown menu alignment */
+#menu_container_2 {
+    top: 60px !important;
+}

--- a/css/prm-search-results.css
+++ b/css/prm-search-results.css
@@ -9,17 +9,17 @@
   flex: 0 0 33.33% !important;
   max-width: 33.33% !important;
   box-sizing: border-box !important;
-  padding-right: 10px !important;
+  /* padding-right: 10px !important; */
 }
-  
-@media (max-width: 1200px) {
+
+@media (max-width: 1450px) {
   .list-item-wrapper {
     flex: 0 0 50% !important;
     max-width: 50% !important;
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 700px) {
   .list-item-wrapper {
     flex: 0 0 100% !important;
     max-width: 100% !important;
@@ -34,6 +34,13 @@ prm-brief-result-container .result-item-image {
   /*width: 100% !important;
   height: auto !important;*/
   flex: 0 0 auto !important;
+}
+
+prm-brief-result-container .result-item-text {
+  padding-right:0;
+}
+.__xs prm-brief-result-container .result-item-text {
+  padding-left: .35em;
 }
 
 /* hide medtia type label 'image' */

--- a/css/prm-search-results.css
+++ b/css/prm-search-results.css
@@ -41,10 +41,12 @@ prm-brief-result-container .result-item-text {
 }
 .__xs prm-brief-result-container .result-item-text {
   padding-left: .35em;
+  margin-top: 0;
 }
 
-/* hide medtia type label 'image' */
-prm-brief-result-container .media-content-type {
+/* hide media type label 'image' */
+prm-brief-result-container .media-content-type,
+.__xs prm-brief-result-container .layout-column > .media-content-type {
   display:none;
 }
 

--- a/css/thumbnail.css
+++ b/css/thumbnail.css
@@ -229,6 +229,10 @@ prm-view-online-after md-grid-list > md-grid-tile {
     background-color: inherit;
 }
 
+prm-brief-result .item-title {
+    max-width: 100%;
+}
+
 prm-brief-result .item-title span {
   -webkit-box-orient: vertical;
   display: -webkit-box;

--- a/css/thumbnail.css
+++ b/css/thumbnail.css
@@ -127,6 +127,10 @@
     height:25px;
 }
 
+.result-item-text + .lockIcon {
+    margin-top: 78px;
+}
+
 .lockIcon > img {
     width:25px;
     height:auto;

--- a/css/thumbnail.css
+++ b/css/thumbnail.css
@@ -126,9 +126,6 @@
     width:25px;
     height:25px;
 }
-.media-thumbnail + .lockIcon {
-    margin-top: -15px;
-}
 
 .lockIcon > img {
     width:25px;

--- a/css/thumbnail.css
+++ b/css/thumbnail.css
@@ -240,6 +240,9 @@ prm-brief-result .item-title span {
   overflow: hidden;
 }
 
+prm-search-result-thumbnail-container {
+    min-width: 70px;
+}
 prm-search prm-search-result-thumbnail-container img {
     width: auto;
 }

--- a/css/thumbnail.css
+++ b/css/thumbnail.css
@@ -126,6 +126,9 @@
     width:25px;
     height:25px;
 }
+.media-thumbnail + .lockIcon {
+    margin-top: -15px;
+}
 
 .lockIcon > img {
     width:25px;

--- a/js/prm-search-results-after.js
+++ b/js/prm-search-results-after.js
@@ -12,7 +12,7 @@
     let vm = this;
     vm.$onInit = function () {
       if(vm.parentCtrl.isFavorites===false) {
-        console.log(vm.parentCtrl);
+
         // Remove left margin on result list grid
         var el = $element[0].parentNode.parentNode.parentNode;
         el.children[0].remove();
@@ -22,20 +22,6 @@
            
           // Use $timeout to execute code after the DOM has been updated
           $timeout(function() {
-            // Search for restricted items and add padlock to the search result
-            newVal.forEach((value, index) => {
-                var htmlString = value.pnx.addata.mis1[0];
-                const parser = new DOMParser();
-                const itemHtml = parser.parseFromString(htmlString, 'text/html');
-                var imageHtml = itemHtml.images[0];
-                if (imageHtml) {
-                    if (imageHtml.attributes.restrictedimage.value == 'true') {
-                        var restrictedItem = angular.element(document.getElementsByClassName('media-thumbnail')[index]);
-                        var padlockIcon = '<div class="lockIcon" tabindex="-1"><img src="custom/HVD_IMAGES/img/icon_lock25.png" class="md-avatar" alt="Restricted to HarvardKey" aria-label="Restricted to HarvardKey" title="Restricted to HarvardKey"/></div>';
-                        restrictedItem.after(padlockIcon);
-                    }
-                }
-            });
             // Update OTB search results
             var searchResultsContainer = angular.element(document.getElementById('searchResultsContainer'));
             // Remove layout column class from the search results container
@@ -44,11 +30,7 @@
             searchResultsContainer.removeAttr('layout');
             // Add layout row class to the search results container
             //searchResultsContainer.addClass('.layout-row');
-
-            // Add padlock icon for restricted items          
-            var lockIcon = '<div class="lockIcon" ng-if="vm.localScope.hideLockIcon" tabindex="-1"><img src="custom/HVD_IMAGES/img/icon_lock25.png" class="md-avatar" alt="Restricted to HarvardKey" aria-label="Restricted to HarvardKey" title="Restricted to HarvardKey"/></div>';
-            searchResultsContainer.after(lockIcon);
-
+            
           }, 1000);
         });
 

--- a/js/prm-search-results-after.js
+++ b/js/prm-search-results-after.js
@@ -12,7 +12,7 @@
     let vm = this;
     vm.$onInit = function () {
       if(vm.parentCtrl.isFavorites===false) {
-
+        console.log(vm.parentCtrl);
         // Remove left margin on result list grid
         var el = $element[0].parentNode.parentNode.parentNode;
         el.children[0].remove();
@@ -22,6 +22,20 @@
            
           // Use $timeout to execute code after the DOM has been updated
           $timeout(function() {
+            // Search for restricted items and add padlock to the search result
+            newVal.forEach((value, index) => {
+                var htmlString = value.pnx.addata.mis1[0];
+                const parser = new DOMParser();
+                const itemHtml = parser.parseFromString(htmlString, 'text/html');
+                var imageHtml = itemHtml.images[0];
+                if (imageHtml) {
+                    if (imageHtml.attributes.restrictedimage.value == 'true') {
+                        var restrictedItem = angular.element(document.getElementsByClassName('media-thumbnail')[index]);
+                        var padlockIcon = '<div class="lockIcon" tabindex="-1"><img src="custom/HVD_IMAGES/img/icon_lock25.png" class="md-avatar" alt="Restricted to HarvardKey" aria-label="Restricted to HarvardKey" title="Restricted to HarvardKey"/></div>';
+                        restrictedItem.after(padlockIcon);
+                    }
+                }
+            });
             // Update OTB search results
             var searchResultsContainer = angular.element(document.getElementById('searchResultsContainer'));
             // Remove layout column class from the search results container
@@ -30,7 +44,11 @@
             searchResultsContainer.removeAttr('layout');
             // Add layout row class to the search results container
             //searchResultsContainer.addClass('.layout-row');
-            
+
+            // Add padlock icon for restricted items          
+            var lockIcon = '<div class="lockIcon" ng-if="vm.localScope.hideLockIcon" tabindex="-1"><img src="custom/HVD_IMAGES/img/icon_lock25.png" class="md-avatar" alt="Restricted to HarvardKey" aria-label="Restricted to HarvardKey" title="Restricted to HarvardKey"/></div>';
+            searchResultsContainer.after(lockIcon);
+
           }, 1000);
         });
 

--- a/js/prm-search-results-after.js
+++ b/js/prm-search-results-after.js
@@ -29,8 +29,9 @@
                 var imageHtml = itemHtml.images[0];
                 if (imageHtml) {
                     if (imageHtml.attributes.restrictedimage.value == 'true') {
-                        var restrictedItem = angular.element(document.getElementsByClassName('result-item-primary-content')[index]);
-                        restrictedItem.append('<p style="color:#ff0000">RESTRICTED ITEM!</p>');
+                        var restrictedItem = angular.element(document.getElementsByClassName('media-thumbnail')[index]);
+                        var padlockIcon = '<div class="lockIcon" tabindex="-1"><img src="custom/HVD_IMAGES/img/icon_lock25.png" class="md-avatar" alt="Restricted to HarvardKey" aria-label="Restricted to HarvardKey" title="Restricted to HarvardKey"/></div>';
+                        restrictedItem.after(padlockIcon);
                     }
                 }
             });

--- a/js/prm-search-results-after.js
+++ b/js/prm-search-results-after.js
@@ -23,6 +23,45 @@
           // Use $timeout to execute code after the DOM has been updated
           $timeout(function() {
             // Search for restricted items and add padlock to the search result
+            findRestricted(newVal);
+            // Update OTB search results
+            var searchResultsContainer = angular.element(document.getElementById('searchResultsContainer'));
+            // Remove layout column class from the search results container
+            searchResultsContainer.removeClass('.layout-column');
+            // Remove layout="column" attribute from the search results container
+            searchResultsContainer.removeAttr('layout');
+            // Add layout row class to the search results container
+            //searchResultsContainer.addClass('.layout-row');
+
+            // Observe all images in the search results to add additional padlocks
+            const observerOptions = {
+                root: null,
+                rootMargin: '0px 0px',
+                threshold: 0
+            };
+            // Create the intersection observer
+            const observer = new IntersectionObserver(function(entries, observer) {
+            // Search for restricted items and add padlock to the search result
+            findRestricted(newVal);
+            }, observerOptions);
+            // Observe all img tags with the 'data-src' attribute
+            document.querySelectorAll('img').forEach(function(img) {
+                observer.observe(img);
+            });
+            // Load an image and unobserve it
+            function load(img, observer) {
+                if (observer) {
+                    img.addEventListener('load', function() { 
+                        observer.unobserve(img);
+                    });
+                }
+            }
+
+          }, 1000);
+        });
+
+        // Reads the data from the search values to find restricted items.
+        function findRestricted(newVal) {
             newVal.forEach((value, index) => {
                 var htmlString = value.pnx.addata.mis1[0];
                 const parser = new DOMParser();
@@ -36,21 +75,7 @@
                     }
                 }
             });
-            // Update OTB search results
-            var searchResultsContainer = angular.element(document.getElementById('searchResultsContainer'));
-            // Remove layout column class from the search results container
-            searchResultsContainer.removeClass('.layout-column');
-            // Remove layout="column" attribute from the search results container
-            searchResultsContainer.removeAttr('layout');
-            // Add layout row class to the search results container
-            //searchResultsContainer.addClass('.layout-row');
-
-            // Add padlock icon for restricted items          
-            var lockIcon = '<div class="lockIcon" ng-if="vm.localScope.hideLockIcon" tabindex="-1"><img src="custom/HVD_IMAGES/img/icon_lock25.png" class="md-avatar" alt="Restricted to HarvardKey" aria-label="Restricted to HarvardKey" title="Restricted to HarvardKey"/></div>';
-            searchResultsContainer.after(lockIcon);
-
-          }, 1000);
-        });
+        }
 
       }
     }

--- a/js/prm-search-results-after.js
+++ b/js/prm-search-results-after.js
@@ -12,6 +12,7 @@
     let vm = this;
     vm.$onInit = function () {
       if(vm.parentCtrl.isFavorites===false) {
+        console.log(vm.parentCtrl);
         // Remove left margin on result list grid
         var el = $element[0].parentNode.parentNode.parentNode;
         el.children[0].remove();
@@ -29,6 +30,10 @@
             searchResultsContainer.removeAttr('layout');
             // Add layout row class to the search results container
             //searchResultsContainer.addClass('.layout-row');
+
+            // Add padlock icon for restricted items          
+            var lockIcon = '<div class="lockIcon" ng-if="vm.localScope.hideLockIcon" tabindex="-1"><img src="custom/HVD_IMAGES/img/icon_lock25.png" class="md-avatar" alt="Restricted to HarvardKey" aria-label="Restricted to HarvardKey" title="Restricted to HarvardKey"/></div>';
+            searchResultsContainer.after(lockIcon);
 
           }, 1000);
         });

--- a/js/prm-search-results-after.js
+++ b/js/prm-search-results-after.js
@@ -30,9 +30,11 @@
                 var imageHtml = itemHtml.images[0];
                 if (imageHtml) {
                     if (imageHtml.attributes.restrictedimage.value == 'true') {
-                        var restrictedItem = angular.element(document.getElementsByClassName('media-thumbnail')[index]);
+                        var restrictedItem = angular.element(document.getElementsByClassName('result-item-primary-content')[index]);
                         var padlockIcon = '<div class="lockIcon" tabindex="-1"><img src="custom/HVD_IMAGES/img/icon_lock25.png" class="md-avatar" alt="Restricted to HarvardKey" aria-label="Restricted to HarvardKey" title="Restricted to HarvardKey"/></div>';
-                        restrictedItem.after(padlockIcon);
+                        restrictedItem.append(padlockIcon);
+                        var restrictedItem2 = angular.element(document.getElementsByClassName('result-item-primary-content')[index]);
+                        restrictedItem2.append('<p style="color:#ff0000">RESTRICTED ITEM!</p>');
                     }
                 }
             });
@@ -44,10 +46,6 @@
             searchResultsContainer.removeAttr('layout');
             // Add layout row class to the search results container
             //searchResultsContainer.addClass('.layout-row');
-
-            // Add padlock icon for restricted items          
-            var lockIcon = '<div class="lockIcon" ng-if="vm.localScope.hideLockIcon" tabindex="-1"><img src="custom/HVD_IMAGES/img/icon_lock25.png" class="md-avatar" alt="Restricted to HarvardKey" aria-label="Restricted to HarvardKey" title="Restricted to HarvardKey"/></div>';
-            searchResultsContainer.after(lockIcon);
 
           }, 1000);
         });

--- a/js/prm-search-results-after.js
+++ b/js/prm-search-results-after.js
@@ -18,9 +18,22 @@
 
         // Watch for new data change when a user search
         vm.parentCtrl.$scope.$watch(() => vm.parentCtrl.searchResults, (newVal, oldVal) => {
-
+           
           // Use $timeout to execute code after the DOM has been updated
           $timeout(function() {
+            // Search for restricted items and add padlock to the search result
+            newVal.forEach((value, index) => {
+                var htmlString = value.pnx.addata.mis1[0];
+                const parser = new DOMParser();
+                const itemHtml = parser.parseFromString(htmlString, 'text/html');
+                var imageHtml = itemHtml.images[0];
+                if (imageHtml) {
+                    if (imageHtml.attributes.restrictedimage.value == 'true') {
+                        var restrictedItem = angular.element(document.getElementsByClassName('result-item-primary-content')[index]);
+                        restrictedItem.append('<p style="color:#ff0000">RESTRICTED ITEM!</p>');
+                    }
+                }
+            });
             // Update OTB search results
             var searchResultsContainer = angular.element(document.getElementById('searchResultsContainer'));
             // Remove layout column class from the search results container

--- a/js/prm-search-results-after.js
+++ b/js/prm-search-results-after.js
@@ -23,45 +23,6 @@
           // Use $timeout to execute code after the DOM has been updated
           $timeout(function() {
             // Search for restricted items and add padlock to the search result
-            findRestricted(newVal);
-            // Update OTB search results
-            var searchResultsContainer = angular.element(document.getElementById('searchResultsContainer'));
-            // Remove layout column class from the search results container
-            searchResultsContainer.removeClass('.layout-column');
-            // Remove layout="column" attribute from the search results container
-            searchResultsContainer.removeAttr('layout');
-            // Add layout row class to the search results container
-            //searchResultsContainer.addClass('.layout-row');
-
-            // Observe all images in the search results to add additional padlocks
-            const observerOptions = {
-                root: null,
-                rootMargin: '0px 0px',
-                threshold: 0
-            };
-            // Create the intersection observer
-            const observer = new IntersectionObserver(function(entries, observer) {
-            // Search for restricted items and add padlock to the search result
-            findRestricted(newVal);
-            }, observerOptions);
-            // Observe all img tags with the 'data-src' attribute
-            document.querySelectorAll('img').forEach(function(img) {
-                observer.observe(img);
-            });
-            // Load an image and unobserve it
-            function load(img, observer) {
-                if (observer) {
-                    img.addEventListener('load', function() { 
-                        observer.unobserve(img);
-                    });
-                }
-            }
-
-          }, 1000);
-        });
-
-        // Reads the data from the search values to find restricted items.
-        function findRestricted(newVal) {
             newVal.forEach((value, index) => {
                 var htmlString = value.pnx.addata.mis1[0];
                 const parser = new DOMParser();
@@ -75,7 +36,21 @@
                     }
                 }
             });
-        }
+            // Update OTB search results
+            var searchResultsContainer = angular.element(document.getElementById('searchResultsContainer'));
+            // Remove layout column class from the search results container
+            searchResultsContainer.removeClass('.layout-column');
+            // Remove layout="column" attribute from the search results container
+            searchResultsContainer.removeAttr('layout');
+            // Add layout row class to the search results container
+            //searchResultsContainer.addClass('.layout-row');
+
+            // Add padlock icon for restricted items          
+            var lockIcon = '<div class="lockIcon" ng-if="vm.localScope.hideLockIcon" tabindex="-1"><img src="custom/HVD_IMAGES/img/icon_lock25.png" class="md-avatar" alt="Restricted to HarvardKey" aria-label="Restricted to HarvardKey" title="Restricted to HarvardKey"/></div>';
+            searchResultsContainer.after(lockIcon);
+
+          }, 1000);
+        });
 
       }
     }

--- a/js/prm-search-results-after.js
+++ b/js/prm-search-results-after.js
@@ -33,8 +33,6 @@
                         var restrictedItem = angular.element(document.getElementsByClassName('result-item-primary-content')[index]);
                         var padlockIcon = '<div class="lockIcon" tabindex="-1"><img src="custom/HVD_IMAGES/img/icon_lock25.png" class="md-avatar" alt="Restricted to HarvardKey" aria-label="Restricted to HarvardKey" title="Restricted to HarvardKey"/></div>';
                         restrictedItem.append(padlockIcon);
-                        var restrictedItem2 = angular.element(document.getElementsByClassName('result-item-primary-content')[index]);
-                        restrictedItem2.append('<p style="color:#ff0000">RESTRICTED ITEM!</p>');
                     }
                 }
             });


### PR DESCRIPTION
### Adjusting padding and breakpoints to make truncation more readable.

Old way:
![WeirdTruncation](https://github.com/cbaksik/HVD_IMAGES/assets/40801910/8e523f2b-e248-4cda-9524-d9323f006587)

New way:
![NewTruncation](https://github.com/cbaksik/HVD_IMAGES/assets/40801910/fb8bfaa0-fb41-469a-a41b-d79d12efc911)

### [LTSDISC-15: Restore main search bar alignment](https://at-harvard.atlassian.net/browse/LTSDISC-15)

The dropdown menu in the main search bar near the top of the page is in alignment with the search bar and the selected repository. 

When "All Harvard Repositories" is selected, the dropdown menu appears below the bar. 

When any other repository is selected the dropdown appears over the bar but with the selected repository is aligned within the searchbar.

Old ways (currently on prod):
![Screenshot 2024-03-12 at 11-00-32 HOLLIS](https://github.com/cbaksik/HVD_IMAGES/assets/13121501/3cc1f046-9df1-481e-a0ba-7c3a9098d164)
![Screenshot 2024-03-12 at 11-00-46 HOLLIS](https://github.com/cbaksik/HVD_IMAGES/assets/13121501/fab9a379-55db-462a-bf6b-ad1bd3097a1a)

New way (aka back to the way it used to be):
![Screenshot 2024-03-12 at 11-00-05 HOLLIS - My Favorites - Search history](https://github.com/cbaksik/HVD_IMAGES/assets/13121501/0b390dfe-e55f-409a-b926-862b12b9e526)
![Screenshot 2024-03-12 at 11-00-20 HOLLIS - My Favorites - Search history](https://github.com/cbaksik/HVD_IMAGES/assets/13121501/d82c2b87-5525-430f-a5e8-abe0e522a49e)

### [LTSDISC-21: Remove "Image" eyebrow from search result layout](https://at-harvard.atlassian.net/browse/LTSDISC-21)

When a user is browsing search results in HOLLIS Images on any view, they do not see the word “Image” as the first fragment of text in every search result on the page (this is for both desktop and mobile views).

### [LTSDISC-14: Restore padlock icon for restricted search results](https://at-harvard.atlassian.net/browse/LTSDISC-14)

When viewing search results in HOLLIS Images, a user will view that thumbnails for restricted items will see a lock icon in the lower left corner.

Old way:
![Screenshot 2024-03-12 at 11-08-33 HOLLIS - ball](https://github.com/cbaksik/HVD_IMAGES/assets/13121501/16e8b1af-e103-4d09-a768-23b01247f91b)

New way:
![Screenshot 2024-03-12 at 11-05-36 HOLLIS - ball](https://github.com/cbaksik/HVD_IMAGES/assets/13121501/74d268ba-5809-4233-a34c-134dc82b6fbe)

### [LTSDISC-20: Set min-width for search result thumbnails](https://at-harvard.atlassian.net/browse/LTSDISC-20)

When a user is browsing search results in HOLLIS Images that have not yet completed loading, search result text like the image title, year, etc., are already shifted to the right, making room for the space that will be filled by the image thumbnail. (You can test this by refreshing and watching the search results page load)

Note: I set the min-width to 70px, so images that are larger than this will still move a bit to the right once the image loads.